### PR TITLE
Add fixed and default attributes to class gen

### DIFF
--- a/lib/wsdl/soap/classDefCreator.rb
+++ b/lib/wsdl/soap/classDefCreator.rb
@@ -369,15 +369,33 @@ private
         constname += "_#{const[constname]}"
       end
       c.def_const(constname, dqname(name))
-      c.def_method(methodname) do <<-__EOD__
-          __xmlattr[#{constname}]
-        __EOD__
+      c.def_method(methodname) do
+        define_reader_method_body(attribute, constname)
       end
-      c.def_method(methodname + '=', 'value') do <<-__EOD__
-          __xmlattr[#{constname}] = value
-        __EOD__
+
+      unless attribute.fixed
+        c.def_method(methodname + '=', 'value') do <<-__EOD__
+            __xmlattr[#{constname}] = value
+          __EOD__
+        end
       end
       c.comment << "\n  #{methodname} - #{attribute_basetype(attribute) || '(any)'}"
+    end
+  end
+
+  def define_reader_method_body(attribute, constname)
+    if f = attribute.fixed
+      <<-__EOD__
+        "#{f}"
+      __EOD__
+    elsif d = attribute.default
+      <<-__EOD__
+        __xmlattr[#{constname}] || "#{d}"
+      __EOD__
+    else
+      <<-__EOD__
+        __xmlattr[#{constname}]
+      __EOD__
     end
   end
 

--- a/lib/wsdl/soap/classDefCreator.rb
+++ b/lib/wsdl/soap/classDefCreator.rb
@@ -278,7 +278,7 @@ private
       parse_elements(c, typedef.elements, qname.namespace, parentmodule)
     unless typedef.attributes.empty?
       define_attribute(c, typedef.attributes)
-      init_lines << "@__xmlattr = {}"
+      init_lines << "@__xmlattr = {}" unless typedef.attributes.all?(&:fixed)
     end
     c.def_method('initialize', *init_params) do
       init_lines.join("\n")
@@ -354,7 +354,7 @@ private
 
   def define_attribute(c, attributes)
     const = {}
-    unless attributes.empty?
+    unless attributes.empty? || attributes.all?(&:fixed)
       c.def_method("__xmlattr") do <<-__EOD__
           @__xmlattr ||= {}
         __EOD__


### PR DESCRIPTION
Attributes can be defined with an fixed or default value in an XSD. This
commit adds coherence to these things when generating classes.